### PR TITLE
feat: Backstop - wait for loaded images

### DIFF
--- a/resources/Visual/check-loaded-images.js
+++ b/resources/Visual/check-loaded-images.js
@@ -1,0 +1,28 @@
+window.addEventListener('load', () => {
+    const images = Array.from(document.querySelectorAll('img')).filter(img => img.checkVisibility());
+    const imageCount = images.length;
+    let loadedImageCount = 0;
+
+    if (!imageCount) {
+        triggerEventComplete();
+    } else {
+        images.forEach((image, index) => {
+            if (image.complete) {
+                countLoaded();
+            } else {
+                image.onload = countLoaded;
+            }
+        });
+    }
+
+    function countLoaded() {
+        loadedImageCount++;
+        if (imageCount === loadedImageCount) {
+            triggerEventComplete();
+        }
+    }
+
+    function triggerEventComplete() {
+        console.log('BackstopVisibleImagesLoaded');
+    }
+});

--- a/resources/Visual/http-server.js
+++ b/resources/Visual/http-server.js
@@ -59,10 +59,6 @@ const server = http.createServer(function (req, res) {
         res.writeHead(200, { 'Content-Type': contentType });
         if (extname === '.html') {
             res.end(modifyResponse(data.toString()), 'utf-8');
-        } else if (extname === '.webp') {
-            setTimeout(() => {
-                res.end(data, 'utf-8');
-            }, 3000);
         } else {
             res.end(data, 'utf-8');
         }

--- a/resources/Visual/http-server.js
+++ b/resources/Visual/http-server.js
@@ -59,6 +59,10 @@ const server = http.createServer(function (req, res) {
         res.writeHead(200, { 'Content-Type': contentType });
         if (extname === '.html') {
             res.end(modifyResponse(data.toString()), 'utf-8');
+        } else if (extname === '.webp') {
+            setTimeout(() => {
+                res.end(data, 'utf-8');
+            }, 3000);
         } else {
             res.end(data, 'utf-8');
         }
@@ -74,8 +78,11 @@ process.on('SIGTERM', () => {
 });
 
 // remove the filesystem part of all paths present in the response
+// and inject a script to notify Backstop when all visible images have been loaded
 function modifyResponse(res) {
     const baseWithoutProtocol = process.env.BASE_URL.replace('file://localhost', '');
+    const checkLoadedImagesScript = fs.readFileSync(__dirname + '/check-loaded-images.js', {encoding: 'utf8', flag: 'r'});
+    res = res + `<script>${checkLoadedImagesScript}</script>`;
     return res.replaceAll(baseWithoutProtocol, '');
 }
 


### PR DESCRIPTION
Logs `BackstopVisibleImagesLoaded` in the console when all visible images have loaded.
Backstop scenarios can opt-in to wait for this event to increase visual test resilience:
```
readyEvent: 'BackstopVisibleImagesLoaded',
readyTimeout: 4000,
```