### PR TITLE
fix: don't pin Symfony Process 6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require-dev": {
         "phpunit/phpunit": "^9.5",
-        "symfony/process": "^6.2"
+        "symfony/process": "^6.0"
     },
     "autoload-dev": {
         "psr-4": {


### PR DESCRIPTION
It requires 8.1+ which isn't required