### PR TITLE
chore: PHP CS Fixer - simplify config

### DIFF
--- a/resources/PHP/php-cs-fixer.php
+++ b/resources/PHP/php-cs-fixer.php
@@ -27,13 +27,6 @@ return static function (string $root, ?string $header = null): Config {
         ->setRules(
             [
                 '@DoctrineAnnotation' => true,
-                '@PHP70Migration' => true,
-                '@PHP70Migration:risky' => true,
-                '@PHP71Migration' => true,
-                '@PHP71Migration:risky' => true,
-                '@PHP73Migration' => true,
-                '@PHP74Migration' => true,
-                '@PHP74Migration:risky' => true,
                 '@PHP80Migration' => true,
                 '@PHP80Migration:risky' => true,
                 '@PhpCsFixer' => true,


### PR DESCRIPTION
PHP80Migration and PHP80Migration:risky contains sets for older PHP versions, no need to declare usage of them manually